### PR TITLE
Support 16.04

### DIFF
--- a/tasks/docker-engine.yml
+++ b/tasks/docker-engine.yml
@@ -16,7 +16,7 @@
 
 - name: Add Docker Engine Repository
   apt_repository:
-    repo: 'deb https://apt.dockerproject.org/repo ubuntu-trusty main'
+    repo: 'deb https://apt.dockerproject.org/repo ubuntu-{{ ansible_distribution_release }} main'
     update_cache: yes
 
 
@@ -26,7 +26,7 @@
 # versions, but not the most recent versions.
 
 - name: Install Docker Engine
-  apt: name="docker-engine={{ docker_version }}-0~trusty" state=present
+  apt: name="docker-engine={{ docker_version }}-0~{{ ansible_distribution_release }}" state=present
   register: docker_engine_install
 
 # If this was the first time Docker was installed, when we gathered facts about

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for docker.ubuntu
 - name: Fail if not a new release of Ubuntu
   fail: msg="{{ ansible_distribution_version }} is not an acceptable version of Ubuntu for this role"
-  when: "ansible_distribution_version not in ['12.04', '13.04', '13.10', '14.04']"
+  when: "ansible_distribution_version not in ['12.04', '13.04', '13.10', '14.04', '16.04']"
 
 # https://docs.docker.com/installation/ubuntulinux/
 - name: Install trusty kernel onto 12.04


### PR DESCRIPTION
Add "16.04" to hardcoded list of supported OS versions.

Don't hardcode "trusty" when configuring the apt repo, use the distro name instead.
