### PR TITLE
Allow configuration of docker daemon.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,6 @@
+Version 2.1:
+  - support Ubuntu 16.04
+  - allow callers to supply "docker
+
 Version 2.0:
   - Port to github

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ docker
 
 Installs Docker on Ubuntu.
 
-Well tested on 14.04. Has been known to work on 12.04.
+Well tested on 14.04. Has been known to work on 12.04 and 16.04.
 
 This role started from the *angstwad* *docker_ubuntu* role and has since forked a bit, primarily
 to manage which version of Docker we install. Because of interdepencies between the Docker API
@@ -21,7 +21,12 @@ Role Variables
 The `docker_version` variable controls what version of Docker is installed.
 
  -  The default `docker_version` is `1.5.0` (for historical reasons). If select, LXC Docker will be used.
- -  Otherwise, the stated version of Docker Engine will be used (if available).
+ -  Otherwise, the stated version of Docker Engine will be used. (If not available, install will fail.)
+
+The `docker_configuration_content` variable may be specified; if so, then the YML content will be converted
+to JSON and stored in /etc/docker/daemon.json. If the file changes, the daemon will be restarted. This allows
+users to specify Docker daemon coonfiguration. For more info, see:
+https://docs.docker.com/engine/reference/commandline/daemon/#daemon-configuration-file
 
 
 Testing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,6 @@ docker_version: 1.5.0
 kernel_pkg_state: latest
 cgroup_lite_pkg_state: latest
 ssh_port: 22
+
+# map containing configuration content
+docker_configuration_content: {}

--- a/tasks/docker-engine.yml
+++ b/tasks/docker-engine.yml
@@ -2,12 +2,13 @@
 # Install docker engine.
 #
 # This is one of at least two mechanisms for installing Docker via apt (the other
-# being the `lxc-docker` package). There is currently only one version of `docker-engine`
-# available, so this mechanism will only work for the most recent `docker_version`,
-# currently `1.8.1`.
+# being the `lxc-docker` package).
+#
+# Docker org now seems to be keeping multiple versions of Docker in their repo, as opposed
+# to when they initially launched, when there was only one version there. So this can be
+# reasonably expected to work for a good range of Docker versions.
 #
 # Installing this docker will remove the lxc-docker package.
-
 
 - name: Add Docker Engine Repository Key
   apt_key:
@@ -19,15 +20,23 @@
     repo: 'deb https://apt.dockerproject.org/repo ubuntu-{{ ansible_distribution_release }} main'
     update_cache: yes
 
+- name: ensure docker config directory exists
+  file: name=/etc/docker state=directory
 
-# While wildcarding the version is cute, in practice, there only seems to be one
-# version of Docker available at a time. I'm not sure what will happen on the next
-# release. Alternatively, we could install LXC Docker, which does have many more
-# versions, but not the most recent versions.
+# write the config file before we install the package, so we can save a restart if possible.
+- name: write docker configuration file
+  copy:
+    dest: /etc/docker/daemon.json
+    content: "{{ docker_configuration_content | to_nice_json }}"
+  register: docker_config_file_update
 
 - name: Install Docker Engine
   apt: name="docker-engine={{ docker_version }}-0~{{ ansible_distribution_release }}" state=present
   register: docker_engine_install
+
+- name: restart Docker after config changed
+  service: name=docker state=restarted
+  when: docker_config_file_update|changed and not docker_engine_install|changed
 
 # If this was the first time Docker was installed, when we gathered facts about
 # the system, we would not have seen the "ansible_docker0" interface, as it wasn't


### PR DESCRIPTION
This patch allows a user to pass in a "docker_configuration_content" variable; content from there will be placed in /etc/docker/daemon.json, and will be thus picked up by the Docker daemon.

One side effect: if someone else is writing that file, the version here may interfere with the version there.
