### PR TITLE
Stop the "docker" service before attempting a package upgrade

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Version 2.1.1:
+ - Stop the "docker" service before attempting a package upgrade, to prevent an intermittent
+   upgrade failure.
+
 Version 2.1:
  - Removed default docker version; "docker_version" is now a required variable.
  - Attempt to handle data volume loss when we update from pre-1.10 to post-1.10.

--- a/tasks/docker-engine.yml
+++ b/tasks/docker-engine.yml
@@ -47,6 +47,15 @@
   register: collect_container_configs_result
   when: "{{ docker_exec_stat_result.stat.exists
             and docker_attempt_upgrade_fixes }}"
+
+# It should be OK to just run the apt install of the new docker package, regardless of the
+# state of docker. However, there's an issue that sometimes occurs in that case, where the
+# processes for the containers that existed before the upgrade aren't stopped by the upgrade, but
+# instead are left hanging around with parent PID 1. Shutting down docker before the upgrade seems
+# to prevent this.
+- name: shut down docker before upgrade
+  service: name=docker state=stopped
+  when: "{{ docker_exec_stat_result.stat.exists and installed_docker_version != docker_version }}"
  
 - name: Install Docker Engine
   apt: name="docker-engine={{ docker_version }}-0~{{ ansible_distribution_release }}" state=present


### PR DESCRIPTION
This is to prevent an intermittent failure where containers were not properly shut down, but container processes remained with parent PID 1.
