### PR TITLE
Remove {{ }}s in conditionals

### DIFF
--- a/tasks/docker-engine.yml
+++ b/tasks/docker-engine.yml
@@ -22,14 +22,14 @@
 - name: see if docker is already installed
   stat: path=/usr/bin/docker get_checksum=False
   register: docker_exec_stat_result
-  always_run: True 
+  always_run: True
 
 - name: Determine installed version
   command: docker --version
   changed_when: False
   always_run: True
   register: docker_version_result
-  when: "{{ docker_exec_stat_result.stat.exists }}"
+  when: docker_exec_stat_result.stat.exists
 
 # "docker --version" output is formatted like this:
 #
@@ -40,13 +40,13 @@
     installed_docker_version: "{{ docker_version_result.stdout
                                   | regex_replace('^Docker version ', '')
                                   | regex_replace(', build [0-9a-f]+$', '') }}"
-  when: "{{ docker_exec_stat_result.stat.exists }}"
+  when: docker_exec_stat_result.stat.exists
 
 - name: collect container data from before upgrade
   collect_container_configs:
   register: collect_container_configs_result
-  when: "{{ docker_exec_stat_result.stat.exists
-            and docker_attempt_upgrade_fixes }}"
+  when: docker_exec_stat_result.stat.exists
+        and docker_attempt_upgrade_fixes
 
 # It should be OK to just run the apt install of the new docker package, regardless of the
 # state of docker. However, there's an issue that sometimes occurs in that case, where the
@@ -55,8 +55,8 @@
 # to prevent this.
 - name: shut down docker before upgrade
   service: name=docker state=stopped
-  when: "{{ docker_exec_stat_result.stat.exists and installed_docker_version != docker_version }}"
- 
+  when: docker_exec_stat_result.stat.exists and installed_docker_version != docker_version
+
 - name: Install Docker Engine
   apt: name="docker-engine={{ docker_version }}-0~{{ ansible_distribution_release }}" state=present
   register: docker_engine_install
@@ -72,15 +72,15 @@
     fix_container_mountpoints: "{{ installed_docker_version | version_compare('1.10', '<')
                                    and docker_version | version_compare('1.10', '>=') }}"
     old_container_configs: "{{ collect_container_configs_result.configs | to_json }}"
-  when: "{{ docker_engine_install | changed 
-            and docker_exec_stat_result.stat.exists
-            and docker_attempt_upgrade_fixes }}"
+  when: docker_engine_install | changed
+        and docker_exec_stat_result.stat.exists
+        and docker_attempt_upgrade_fixes
   register: repair_docker_data_volumes_result
 
 - name: start docker after repair of docker settings
   service: name=docker state=started
-  when: "{{ repair_docker_data_volumes_result is defined
-            and repair_docker_data_volumes_result | changed }}"
+  when: repair_docker_data_volumes_result is defined
+        and repair_docker_data_volumes_result | changed
 
 # If we just installed or upgraded Docker, re-read Docker-related facts.
 - name: reread facts about ansible_docker0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: check that docker_version is set
   fail: msg="Required variable \"docker_version\" is not defined."
-  when: "{{ docker_version is not defined }}"
+  when: docker_version is not defined
 
 # https://docs.docker.com/installation/ubuntulinux/
 - name: Install trusty kernel onto 12.04
@@ -64,11 +64,11 @@
 
 - name: Install LXC Docker
   include: lxc-docker.yml
-  when: "{{ docker_version == '1.5.0' }}"
+  when: docker_version == '1.5.0'
 
 - name: Install Docker Engine
   include: docker-engine.yml
-  when: "{{ docker_version != '1.5.0' }}"
+  when: docker_version != '1.5.0'
 
 - name: Ensure that Docker is running
   service: name="docker" state=started

--- a/tests/no_upgrade_fixes_part2.yml
+++ b/tests/no_upgrade_fixes_part2.yml
@@ -6,6 +6,7 @@
     - name: grab old volume ID
       command: ls /var/lib/docker/vfs/dir
       register: vfs_dir_result
+
     - name: store old volume ID
       set_fact:
         old_volume_id: "{{ vfs_dir_result.stdout }}"
@@ -18,17 +19,21 @@
     - name: look at the volume symlink
       stat: path=/var/lib/docker/volumes/_data
       register: volume_symlink_stat
+
     - name: verify the link does not exist
       assert:
         that:
           - "not volume_symlink_stat.stat.exists"
+
     - name: start old container that uses data volume
       command: docker start volume-user
+
     - name: verify that old volume-using container cannot read unmapped volume
       command: docker exec volume-user stat /opt/some/volume/cpuinfo
       register: old_volume_user_read_unmapped_result
-      failed_when: "{{ old_volume_user_read_unmapped_result.rc == 0 }}"
+      failed_when: old_volume_user_read_unmapped_result.rc == 0
+
     - name: verify that old volume-using container cannot read mapped volume
       command: docker exec volume-user stat /externalstuff/alternatives/README
       register: old_volume_user_read_mapped_result
-      failed_when: "{{ old_volume_user_read_mapped_result.rc == 0 }}"
+      failed_when: old_volume_user_read_mapped_result.rc == 0


### PR DESCRIPTION
Remove `{{ }}`s in `when` conditions.  This fixes an annoying Ansible syntax warning.

```
[WARNING]: It is unnecessary to use '{{' in conditionals, leave variables in loop expressions bare.
```
