### PR TITLE
Wait for Docker to start before re-reading Ansible facts. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+Version 2.2.1:
+ - wait for Docker to actually be running before re-reading ansible docker facts.
+
 Version 2.2:
  - Removed the upgrade fixes added in Version 2.1.
  - No longer pass the "--force-confnew" flag to apt when installing the Docker package.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,9 @@ docker_role_apt_cache_valid_time: 7200
 
 # These flags are passed to the Docker daemon on startup.
 docker_daemon_flags: ""
+
+
+# When we start / restart Docker, this role waits until it is ready before
+# proceeding. This variable controls how long we wait before giving up.
+# This value should be OK for all but the slowest servers.
+docker_daemon_startup_timeout_sec: 10

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,7 +86,7 @@
   command: docker info
   register: r_docker_info
   until: r_docker_info.rc == 0
-  retries: 10
+  retries: "{{ docker_daemon_startup_timeout_sec }}"
   delay: 1
 
 - name: reread docker facts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,6 +82,13 @@
 - name: Ensure that Docker is running
   service: name="docker" state=started
 
+- name: Wait until docker daemon is available
+  command: docker info
+  register: r_docker_info
+  until: r_docker_info.rc == 0
+  retries: 10
+  delay: 1
+
 - name: reread docker facts
   setup: filter=ansible_docker0
   when: r_etc_default_docker|changed or r_docker_package_install|changed


### PR DESCRIPTION
"service state=started" doesn't wait until the service is actually running, so it was possible that we'd
try to reread docker facts before Docker had started, and they'd stay blank.
