### PR TITLE
Generalize LTS kernel upgrades to 14.04 and to vagrant

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,10 +45,6 @@
   register: cgroup_lite_result
   when: ansible_distribution_version == '13.10'
 
-- name: Is reboot necessary?
-  set_fact:
-    reboot_needed: "{{(kernel_result or cgroup_lite_result or {'changed': False}) | changed}}"
-
 - include: reboot-and-wait.yml
 
 # Newer versions of Docker no longer require apparmor, but it seems like a good thing to have.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,25 +11,29 @@
   when: docker_version is not defined
 
 # https://docs.docker.com/installation/ubuntulinux/
-- name: Install trusty kernel onto 12.04
+- name: Install backported kernel on pre-16.04 LTS
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ item.name }}"
     state: latest
     update_cache: yes
     cache_valid_time: "{{ docker_role_apt_cache_valid_time }}"
   with_items:
-    - linux-image-generic-lts-trusty
-    - linux-headers-generic-lts-trusty
+    - name: linux-image-generic-lts-trusty
+      version: "12.04"
+    - name: linux-headers-generic-lts-trusty
+      version: "12.04"
+    - name: linux-image-generic-lts-xenial
+      version: "14.04"
   register: kernel_result
-  when: ansible_distribution_version == '12.04'
+  when: ansible_distribution_version == item.version
 
-- name: Install latest kernel extras for Ubuntu 13.04+
+- name: Install latest kernel extras for Ubuntu 13.04, 13.10
   apt:
     pkg: "linux-image-extra-{{ ansible_kernel }}"
     state: "{{ kernel_pkg_state }}"
     update_cache: yes
     cache_valid_time: "{{ docker_role_apt_cache_valid_time }}"
-  when: ansible_distribution_version != '12.04'
+  when: ansible_distribution_version in ['13.04', '13.10']
 
 # Fix for https://github.com/dotcloud/docker/issues/4568
 - name: Install cgroup-lite for Ubuntu 13.10

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,22 +45,11 @@
   register: cgroup_lite_result
   when: ansible_distribution_version == '13.10'
 
-- name: Reboot instance
-  command: /sbin/shutdown -r now
-  register: reboot_result
-  when: "(ansible_distribution_version == '12.04' and kernel_result|changed)
-      or (ansible_distribution_version == '13.10' and cgroup_lite_result|changed)"
+- name: Is reboot necessary?
+  set_fact:
+    reboot_needed: "{{(kernel_result or cgroup_lite_result or {'changed': False}) | changed}}"
 
-- name: Wait for instance to come online
-  local_action:
-    module: wait_for
-    host: "{{ ansible_ssh_host|default(inventory_hostname) }}"
-    port: "{{ ansible_ssh_port|default(ssh_port) }}"
-    delay: 30
-    timeout: 600
-    state: started
-  when: "(ansible_distribution_version == '12.04' and reboot_result|changed)
-      or (ansible_distribution_version == '13.10' and cgroup_lite_result|changed)"
+- include: reboot-and-wait.yml
 
 # Newer versions of Docker no longer require apparmor, but it seems like a good thing to have.
 - name: Install apparmor

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,8 +10,15 @@
   fail: msg="Required variable \"docker_version\" is not defined."
   when: docker_version is not defined
 
-# https://docs.docker.com/installation/ubuntulinux/
-- name: Install backported kernel on pre-16.04 LTS
+# https://docs.docker.com/engine/installation/linux/ubuntulinux/#/prerequisites-by-ubuntu-version
+# - 12.04: Docker requires the 3.13 kernel version.
+#          Ensure the trusty kernel is installed.
+# - 14.04: Support aufs via the linux-image-extra-* kernel package.
+#          Achieve this with the xenial kernel, which depends on the
+#          corresponding extra package, to address issues with kernels
+#          before 3.19 at the same time.
+#          https://github.com/docker/docker/issues/21704#issuecomment-235365424
+- name: Install HWE kernel on pre-16.04 LTS
   apt:
     pkg: "{{ item.name }}"
     state: latest

--- a/tasks/reboot-and-wait.yml
+++ b/tasks/reboot-and-wait.yml
@@ -1,18 +1,22 @@
 ---
 # reboot an Ubuntu machine if needed and wait for it to come back
+- name: Detect vagrant instance
+  set_fact:
+    is_vagrant: "{{is_vagrant | default(ansible_ssh_user == 'vagrant')}}"
+
 - name: Reboot instance
   command: /sbin/shutdown -r now
   register: reboot_result
   when:
     - reboot_needed
-    - ansible_ssh_user != 'vagrant'
+    - not is_vagrant
 
 - name: Reboot vagrant instance
   local_action: command vagrant reload "{{inventory_hostname}}"
   register: reboot_result
   when:
     - reboot_needed
-    - ansible_ssh_user == 'vagrant'
+    - is_vagrant
   become: false
 
 - name: Wait for instance to come online

--- a/tasks/reboot-and-wait.yml
+++ b/tasks/reboot-and-wait.yml
@@ -3,7 +3,17 @@
 - name: Reboot instance
   command: /sbin/shutdown -r now
   register: reboot_result
-  when: reboot_needed
+  when:
+    - reboot_needed
+    - ansible_ssh_user != 'vagrant'
+
+- name: Reboot vagrant instance
+  local_action: command vagrant reload "{{inventory_hostname}}"
+  register: reboot_result
+  when:
+    - reboot_needed
+    - ansible_ssh_user == 'vagrant'
+  become: false
 
 - name: Wait for instance to come online
   local_action:

--- a/tasks/reboot-and-wait.yml
+++ b/tasks/reboot-and-wait.yml
@@ -6,17 +6,13 @@
 
 - name: Reboot instance
   command: /sbin/shutdown -r now
+  args:
+    removes: /var/run/reboot-required
   register: reboot_result
-  when:
-    - reboot_needed
-    - not is_vagrant
 
-- name: Reboot vagrant instance
+- name: Reload vagrant instance
   local_action: command vagrant reload "{{inventory_hostname}}"
-  register: reboot_result
-  when:
-    - reboot_needed
-    - is_vagrant
+  when: reboot_result|changed and is_vagrant
   become: false
 
 - name: Wait for instance to come online
@@ -29,4 +25,3 @@
     state: started
   when: reboot_result|changed
   become: false
-

--- a/tasks/reboot-and-wait.yml
+++ b/tasks/reboot-and-wait.yml
@@ -1,0 +1,18 @@
+---
+# reboot an Ubuntu machine if needed and wait for it to come back
+- name: Reboot instance
+  command: /sbin/shutdown -r now
+  register: reboot_result
+  when: reboot_needed
+
+- name: Wait for instance to come online
+  local_action:
+    module: wait_for
+    host: "{{ ansible_ssh_host|default(inventory_hostname) }}"
+    port: "{{ ansible_ssh_port|default(ssh_port) }}"
+    delay: 30
+    timeout: 600
+    state: started
+  when: reboot_result|changed
+  become: false
+


### PR DESCRIPTION
- Change the logic on what needs upgrading to pick up the LTS HWE kernel on 14.04 and to explicitly install kernel extras only for 13.x.
- Factor out the reboot logic
- Add a `vagrant reload` for vagrant instances, so vagrant-cachier (et al?) works after the reboot