### PR TITLE
Fix false positives on vagrant detection

### DIFF
--- a/tasks/reboot-and-wait.yml
+++ b/tasks/reboot-and-wait.yml
@@ -2,7 +2,7 @@
 # reboot an Ubuntu machine if needed and wait for it to come back
 - name: Detect vagrant instance
   set_fact:
-    is_vagrant: "{{is_vagrant | default(ansible_ssh_user == 'vagrant')}}"
+    is_vagrant: "{{is_vagrant | default(ansible_user_id == 'vagrant' or ansible_env['SUDO_USER'] == 'vagrant')}}"
 
 - name: Reboot instance
   command: /sbin/shutdown -r now
@@ -12,7 +12,7 @@
 
 - name: Reload vagrant instance
   local_action: command vagrant reload "{{inventory_hostname}}"
-  when: reboot_result|changed and is_vagrant
+  when: reboot_result|changed and is_vagrant|bool
   become: false
 
 - name: Wait for instance to come online


### PR DESCRIPTION
- Use `ansible_user_id` and `ansible_env['SUDO_USER']` to detect
  a (probable) vagrant instance. The `ansible_ssh_user` variable won't
  necessarily be set (e.g., when .ssh/config handles any user
  translation), and its name changed to `ansible_user` in 2.x.

- For 1.9, add the `|bool` filter on `is_vagrant`. Without, the fact
  expands to the string `"False"`, which is true. Ansible 2.x doesn't
  need the filter, but it doesn't hurt there, either.