### PR TITLE
Add distribution name for docker 1.12.4+

### DIFF
--- a/tasks/docker-engine.yml
+++ b/tasks/docker-engine.yml
@@ -34,9 +34,21 @@
 # i.e. if there's a -0 and a -1 we'll get -1.
 #
 # Reference: https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
+#
+# Beginning with Docker 1.12.4, the version includes the distribution name:
+#
+#   1.12.4-0~ubuntu-trusty
+#
+# Include the distribution name as needed
 - name: Install Docker Engine
   apt:
-    name: "docker-engine={{ docker_version }}-*~{{ ansible_distribution_release }}"
+    name: "docker-engine={{ docker_version }}-*~{{
+             docker_version
+               | version_compare('1.12.4', '>=')
+               | ternary(ansible_distribution + '-', '')
+           }}{{
+             ansible_distribution_release
+           }}"
     state: present
   register: r_docker_package_install
   when: not check_mode


### PR DESCRIPTION
Beginning with Docker 1.12.4, the version includes the distribution name:

     1.12.4-0~ubuntu-trusty

Include the distribution name (`ansible_distribution`) and hyphen for docker_version >= 1.12.4.